### PR TITLE
Combine the Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,12 @@
-coq: Makefile.plugin.coq Makefile.coq
-	$(MAKE) -f Makefile.plugin.coq
+coq: Makefile.coq
 	$(MAKE) -f Makefile.coq
 
 install: coq
-	$(MAKE) -f Makefile.plugin.coq install
 	$(MAKE) -f Makefile.coq install
 
-clean: Makefile.coq Makefile.plugin.coq
-	$(MAKE) -f Makefile.plugin.coq clean
+clean: Makefile.coq
 	$(MAKE) -f Makefile.coq clean
-	rm -f Makefile.plugin.coq Makefile.coq
-
-Makefile.plugin.coq: _CoqProject
-	coq_makefile src/reify.ml4 src/template_plugin.mlpack -o Makefile.plugin.coq
+	rm -f Makefile.coq
 
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,6 @@
 -I src
 -R theories Template
+src/reify.ml4
+src/template_plugin.mlpack
 theories/Ast.v
 theories/Template.v


### PR DESCRIPTION
I think the coq_makefile install target doesn't install plugins if there
are no .v files?  I'm not really sure, but, previously, the install
target of Makefile.plugin.coq didn't do anything, and now the install
target installs the plugin files.

This should also be copied onto the 8.5 branch, probably, though I haven't checked that.