### PR TITLE
Put the Ast in [Set] rather than [Type]

### DIFF
--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -4,37 +4,37 @@ Require Import Coq.PArith.BinPos.
 Definition universe := positive.
 Definition ident := string.
 
-Inductive sort : Type :=
+Inductive sort : Set :=
 | sProp
 | sSet
 | sType (_ : universe).
 
-Record ind : Type := {} .
+Record ind : Set := {} .
 
-Inductive name : Type :=
+Inductive name : Set :=
 | nAnon
 | nNamed (_ : ident).
 
-Inductive cast_kind : Type :=
+Inductive cast_kind : Set :=
 | VmCast
 | NativeCast
 | Cast
 | RevertCast.
 
-Inductive inductive : Type :=
+Inductive inductive : Set :=
 | mkInd : string -> nat -> inductive.
 
-Record def (term : Type) : Type := mkdef
+Record def (term : Set) : Set := mkdef
 { dname : name (** the name (note, this may mention other definitions **)
 ; dtype : term
 ; dbody : term (** the body (a lambda term) **)
 ; rarg  : nat  (** the index of the recursive argument **)
 }.
 
-Definition mfixpoint (term : Type) : Type :=
+Definition mfixpoint (term : Set) : Set :=
   list (def term).
 
-Inductive term : Type :=
+Inductive term : Set :=
 | tRel       : nat -> term
 | tVar       : ident -> term (** this can go away **)
 | tMeta      : nat -> term   (** NOTE: this can go away *)
@@ -58,7 +58,7 @@ Inductive term : Type :=
 Record inductive_body := mkinductive_body
 { ctors : list (ident * term) }.
 
-Inductive program : Type :=
+Inductive program : Set :=
 | PConstr : string -> term -> program -> program
 | PType   : ident -> list (ident * inductive_body) -> program -> program
 | PAxiom  : ident -> program -> program


### PR DESCRIPTION
This makes it simpler for the datatype to quote itself without messing
around with universes.