### PR TITLE
Use the arity information of constructors

### DIFF
--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -56,7 +56,7 @@ Inductive term : Type :=
 | tUnknown : string -> term.
 
 Record inductive_body := mkinductive_body
-{ ctors : list (ident * term) }.
+{ ctors : list (ident * term * nat (* arity, without lets *)) }.
 
 Inductive program : Type :=
 | PConstr : string -> term -> program -> program


### PR DESCRIPTION
... that comes from the kernel (not used by the kernel itself though, only the normalized
arity is, mind_nf_lc).