### PR TITLE
Fix a bug in casting proofs in Prop

### DIFF
--- a/test-suite/castprop.v
+++ b/test-suite/castprop.v
@@ -6,11 +6,15 @@ Definition foo (x : nat) (p : True) := p.
 
 Quote Recursively Definition q_foo := foo.
 
+Definition fooapp := foo 0 I.
+Quote Recursively Definition q_fooapp := @fooapp.
+Definition f (x : nat) (p : True) (y : nat) := y.
+
+Definition fapp (x : nat) := f 0 I x.
+Quote Recursively Definition q_fapp := @fapp.
 
 Definition setprop : { x : nat | x = 0 } := exist _ 0 eq_refl.
-
-
 Quote Recursively Definition q_setprop := setprop.
 
-Notation proof t := (Ast.tCast (Ast.tCast t Ast.Cast _)
-                               Ast.Cast (Ast.tSort Ast.sProp)).
+Notation proof t :=
+  (Ast.tCast t Ast.Cast (Ast.tCast _ Ast.Cast (Ast.tSort Ast.sProp))).


### PR DESCRIPTION
It was casting the term with Prop and not its type...

Also rework implementation of tagging to be purely functional,
passing the in_prop flag along with the environment during reification.

Expand test-suite too.