### PR TITLE
Fix bugs with LetIn

### DIFF
--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -256,7 +256,7 @@ struct
 	let (t',acc) = quote_term acc env t in
 	let (b',acc) = quote_term acc (push_rel (n, None, t) env) b in
 	(Term.mkApp (tLambda, [| quote_name n ; t' ; b' |]), acc)
-      | Term.LetIn (n,t,e,b) ->
+      | Term.LetIn (n,e,t,b) ->
 	let (t',acc) = quote_term acc env t in
 	let (e',acc) = quote_term acc env e in
 	let (b',acc) = quote_term acc (push_rel (n, Some e, t) env) b in
@@ -597,7 +597,7 @@ struct
     else if Term.eq_constr h tLetIn then
       match args with
 	n :: t :: e :: b :: _ ->
-	  Term.mkLetIn (unquote_name n, denote_term t, denote_term e, denote_term b)
+	  Term.mkLetIn (unquote_name n, denote_term e, denote_term t, denote_term b)
       | _ -> raise (Failure "ill-typed (let-in)")
     else if Term.eq_constr h tApp then
       match args with

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -257,10 +257,10 @@ struct
 	let (b',acc) = quote_term acc (push_rel (n, None, t) env) b in
 	(Term.mkApp (tLambda, [| quote_name n ; t' ; b' |]), acc)
       | Term.LetIn (n,e,t,b) ->
-	let (t',acc) = quote_term acc env t in
 	let (e',acc) = quote_term acc env e in
+	let (t',acc) = quote_term acc env t in
 	let (b',acc) = quote_term acc (push_rel (n, Some e, t) env) b in
-	(Term.mkApp (tLetIn, [| quote_name n ; t' ; e' ; b' |]), acc)
+	(Term.mkApp (tLetIn, [| quote_name n ; e'; t' ; b' |]), acc)
       | Term.App (f,xs) ->
 	let (f',acc) = quote_term acc env f in
 	let (xs',acc) =
@@ -596,7 +596,7 @@ struct
       | _ -> raise (Failure "ill-typed (lambda)")
     else if Term.eq_constr h tLetIn then
       match args with
-	n :: t :: e :: b :: _ ->
+	n :: e :: t :: b :: _ ->
 	  Term.mkLetIn (unquote_name n, denote_term e, denote_term t, denote_term b)
       | _ -> raise (Failure "ill-typed (let-in)")
     else if Term.eq_constr h tApp then

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -12,3 +12,4 @@ demo.v
 hnf_ctor.v
 mutind.v
 opaque.v
+letin.v

--- a/test-suite/letin.v
+++ b/test-suite/letin.v
@@ -1,0 +1,12 @@
+Require Import Template.Template.
+
+Local Open Scope string_scope.
+
+Notation test := (let x := 2 in x).
+
+Quote Definition letin_syntax := test.
+
+Make Definition letin_from_syntax :=
+  ltac:(let r := eval red in letin_syntax in exact r).
+
+Check (eq_refl : letin_from_syntax = test).

--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -43,7 +43,7 @@ Inductive term : Set :=
 | tCast      : term -> cast_kind -> term -> term
 | tProd      : name -> term (** the type **) -> term -> term
 | tLambda    : name -> term (** the type **) -> term -> term
-| tLetIn     : name -> term (** the type **) -> term -> term -> term
+| tLetIn     : name -> term (** the term **) -> term (** the type **) -> term -> term
 | tApp       : term -> list term -> term
 | tConst     : string -> term
 | tInd       : inductive -> term


### PR DESCRIPTION
In Coq's representation the body comes first, unlike tLetIn
Fixed quote and unquoting as well and added a test in the test-suite.