### PR TITLE
Change representation of cases, fix denote function

### DIFF
--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -13,3 +13,4 @@ hnf_ctor.v
 mutind.v
 opaque.v
 letin.v
+case.v

--- a/test-suite/case.v
+++ b/test-suite/case.v
@@ -1,0 +1,16 @@
+Require Import Template.Template.
+
+Definition f := fun (n : nat) =>
+  match n with
+  | 0 => 0
+  | S n => n
+  end.
+
+
+Quote Definition f_quoted :=
+  ltac:(let t := eval cbv in f in exact t).
+
+Make Definition f_from_syntax :=
+  ltac:(let t := eval cbv in f_quoted in exact t).
+
+Check eq_refl : f = f_from_syntax.

--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -9,8 +9,6 @@ Inductive sort : Set :=
 | sSet
 | sType (_ : universe).
 
-Record ind : Set := {} .
-
 Inductive name : Set :=
 | nAnon
 | nNamed (_ : ident).
@@ -48,7 +46,8 @@ Inductive term : Set :=
 | tConst     : string -> term
 | tInd       : inductive -> term
 | tConstruct : inductive -> nat -> term
-| tCase      : nat (* # of parameters *) -> term (** type info **) -> term -> list (nat * term) -> term
+| tCase      : (inductive * nat) (* # of parameters *) -> term (** type info **) -> term ->
+               list (nat * term) -> term
 | tFix       : mfixpoint term -> nat -> term
 (*
 | CoFix     of ('constr, 'types) pcofixpoint


### PR DESCRIPTION
This adds the inductive type on which the case is performed to the case
constructors.

Fixed the denotation of cases (new info and previous change of repr of
branches).