### PR TITLE
Complete reification and fix a few bugs

### DIFF
--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -98,6 +98,8 @@ module type Quoter = sig
 
   val mkRel : quoted_int -> t
   val mkVar : quoted_ident -> t
+  val mkMeta : quoted_int -> t
+  val mkEvar : quoted_int -> t array -> t
   val mkSort : quoted_sort -> t
   val mkCast : t -> quoted_cast_kind -> t -> t
   val mkProd : quoted_name -> t -> t -> t
@@ -109,9 +111,9 @@ module type Quoter = sig
   val mkConstruct : quoted_inductive * quoted_int -> t
   val mkCase : (quoted_inductive * quoted_int) -> quoted_int list -> t -> t ->
                t list -> t
+  val mkProj : quoted_kernel_name -> t -> t
   val mkFix : (quoted_int array * quoted_int) * (quoted_name array * t array * t array) -> t
-  val mkUnknown : Constr.t -> t
-
+  val mkCoFix : quoted_int * (quoted_name array * t array * t array) -> t
 
   val mkMutualInductive : quoted_kernel_name -> quoted_int (* params *) ->
                           (quoted_ident * (quoted_ident * t * quoted_int) list) list ->
@@ -185,11 +187,11 @@ struct
   let tIndTy = r_reify "inductive"
   let tmkInd = r_reify "mkInd"
   let (tTerm,tRel,tVar,tMeta,tEvar,tSort,tCast,tProd,
-       tLambda,tLetIn,tApp,tCase,tFix,tConstructor,tConst,tInd,tUnknown) =
+       tLambda,tLetIn,tApp,tCase,tFix,tConstructor,tConst,tInd,tCoFix,tProj) =
     (r_reify "term", r_reify "tRel", r_reify "tVar", r_reify "tMeta", r_reify "tEvar",
      r_reify "tSort", r_reify "tCast", r_reify "tProd", r_reify "tLambda",
      r_reify "tLetIn", r_reify "tApp", r_reify "tCase", r_reify "tFix",
-     r_reify "tConstruct", r_reify "tConst", r_reify "tInd", r_reify "tUnknown")
+     r_reify "tConstruct", r_reify "tConst", r_reify "tInd", r_reify "tCoFix", r_reify "tProj")
 
   let (tdef,tmkdef) = (r_reify "def", r_reify "mkdef")
   let (tLocalDef,tLocalAssum) = (r_reify "LocalDef", r_reify "LocalAssum")
@@ -332,9 +334,10 @@ struct
   let quote_kn kn = quote_string (Names.string_of_kn kn)
   let mkRel i = Term.mkApp (tRel, [| i |])
   let mkVar id = Term.mkApp (tVar, [| id |])
+  let mkMeta i = Term.mkApp (tMeta, [| i |])
+  let mkEvar n args = Term.mkApp (tEvar, [| n; to_coq_list tTerm (Array.to_list args) |])
   let mkSort s = Term.mkApp (tSort, [| s |])
   let mkCast c k t = Term.mkApp (tCast, [| c ; k ; t |])
-  let mkUnknown trm = (Term.mkApp (tUnknown, [| quote_string (Format.asprintf "%a" pp_constr trm) |]))
   let mkConst kn = Term.mkApp (tConst, [| kn |])
   let mkProd na t b =
     Term.mkApp (tProd, [| na ; t ; b |])
@@ -346,13 +349,11 @@ struct
   let mkLetIn na t t' b =
     Term.mkApp (tLetIn, [| na ; t ; t' ; b |])
 
+  let rec seq f t =
+    if f < t then f :: seq (f + 1) t
+    else []
+
   let mkFix ((a,b),(ns,ts,ds)) =
-    let rec seq f t =
-      if f < t then
-	f :: seq (f + 1) t
-      else
-	[]
-    in
     let mk_fun xs i =
       Term.mkApp (tmkdef, [| tTerm ; Array.get ns i ;
                              Array.get ts i ; Array.get ds i ; Array.get a i |]) :: xs
@@ -360,6 +361,15 @@ struct
     let defs = List.fold_left mk_fun [] (seq 0 (Array.length a)) in
     let block = to_coq_list (Term.mkApp (tdef, [| tTerm |])) (List.rev defs) in
     Term.mkApp (tFix, [| block ; b |])
+
+  let mkCoFix (a,(ns,ts,ds)) =
+    let mk_fun xs i =
+      Term.mkApp (tmkdef, [| tTerm ; Array.get ns i ;
+                             Array.get ts i ; Array.get ds i ; tO |]) :: xs
+    in
+    let defs = List.fold_left mk_fun [] (seq 0 (Array.length ns)) in
+    let block = to_coq_list (Term.mkApp (tdef, [| tTerm |])) (List.rev defs) in
+    Term.mkApp (tCoFix, [| block ; a |])
 
   let mkConstruct (ind, i) = 
     Term.mkApp (tConstructor, [| ind ; i |])
@@ -372,6 +382,9 @@ struct
     let tl = prod tnat tTerm in
     Term.mkApp (tCase, [| info ; p ; c ; to_coq_list tl branches |])
 
+  let mkProj kn t =
+    Term.mkApp (tProj, [| kn; t |])
+
   let mkMutualInductive kn p ls =
     let result = to_coq_list (prod tident tinductive_body)
          (List.map (fun (a,b) ->
@@ -379,6 +392,7 @@ struct
 	                        pair tident tinductive_body a b) (List.rev ls)) in
     Term.mkApp (pType, [| kn; p; result |])
 
+    
   let mkConstant kn c =
     Term.mkApp (pConstr, [| kn; c |])
 
@@ -403,6 +417,13 @@ struct
       match Term.kind_of_term trm with
 	Term.Rel i -> (Q.mkRel (Q.quote_int (i - 1)), acc)
       | Term.Var v -> (Q.mkVar (Q.quote_ident v), acc)
+      | Term.Meta n -> (Q.mkMeta (Q.quote_int n), acc)
+      | Term.Evar (n,args) ->
+	let (acc,args') =
+	  CArray.fold_map (fun acc x ->
+	    let (x,acc) = quote_term acc env x in acc,x)
+	                  acc args in
+         (Q.mkEvar (Q.quote_int (Evar.repr n)) args', acc)
       | Term.Sort s -> (Q.mkSort (Q.quote_sort s), acc)
       | Term.Cast (c,k,t) ->
 	let (c',acc) = quote_term acc env c in
@@ -451,8 +472,13 @@ struct
             (x :: xs, narg :: nargs, acc))
           ([],[],acc) e ci.Term.ci_cstr_nargs in
         (Q.mkCase (ind, npar) (List.rev nargs) a' b' (List.rev branches), acc)
-      | Term.Fix fp -> quote_fixpoint acc env fp 
-      | _ -> (Q.mkUnknown trm, acc)
+      | Term.Fix fp -> quote_fixpoint acc env fp
+      | Term.CoFix fp -> quote_cofixpoint acc env fp
+      | Term.Proj (p,c) ->
+         let kn = Names.Constant.canonical (Names.Projection.constant p) in
+         let p' = Q.quote_kn kn in
+         let t', acc = quote_term acc env c in
+         (Q.mkProj p' t', add_constant kn acc)
       in
       let in_prop, env' = env in
       if is_cast_prop () && not in_prop then
@@ -476,18 +502,25 @@ struct
                             Term.mkCast (ty, Term.DEFAULTcast, Term.mkProp)))
         else aux acc env trm
       else aux acc env trm
-    and quote_fixpoint (acc : 'a) env t =
-      let ((a,b),(ns,ts,ds)) = t in
+    and quote_recdecl (acc : 'a) env b (ns,ts,ds) =
       let ctxt = CArray.map2_i (fun i na t -> (Context.Rel.Declaration.LocalAssum (na, Vars.lift i t))) ns ts in
       let envfix = push_rel_context (CArray.rev_to_list ctxt) env in
       let ns' = Array.map Q.quote_name ns in
-      let a' = Array.map Q.quote_int a in
       let b' = Q.quote_int b in
       let acc, ts' =
         CArray.fold_map (fun acc t -> let x,acc = quote_term acc env t in acc, x) acc ts in
       let acc, ds' =
         CArray.fold_map (fun acc t -> let x,y = quote_term acc envfix t in y, x) acc ds in
-      (Q.mkFix ((a',b'),(ns',ts',ds')), acc)
+      ((b',(ns',ts',ds')), acc)
+    and quote_fixpoint acc env t =
+      let ((a,b),decl) = t in
+      let a' = Array.map Q.quote_int a in
+      let (b',decl'),acc = quote_recdecl acc env b decl in
+      (Q.mkFix ((a',b'),decl'), acc)
+    and quote_cofixpoint acc env t =
+      let (a,decl) = t in
+      let (a',decl'),acc = quote_recdecl acc env a decl in
+      (Q.mkCoFix (a',decl'), acc)
     and quote_minductive_type (acc : 'a) env (t : Names.mutual_inductive) =
       let mib = Environ.lookup_mind t (snd env) in
       let inst = Univ.UContext.instance mib.Declarations.mind_universes in

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -116,10 +116,11 @@ module type Quoter = sig
   val mkCoFix : quoted_int * (quoted_name array * t array * t array) -> t
 
   val mkMutualInductive : quoted_kernel_name -> quoted_int (* params *) ->
-                          (quoted_ident * (quoted_ident * t * quoted_int) list) list ->
+                          (quoted_ident * t (* ind type *) *
+                             (quoted_ident * t (* constr type *) * quoted_int) list) list ->
                           quoted_decl
 
-  val mkConstant : quoted_kernel_name -> t -> quoted_decl
+  val mkConstant : quoted_kernel_name -> t (* type *) -> t (* body *) -> quoted_decl
   val mkAxiom : quoted_kernel_name -> t -> quoted_decl
 
   val mkExt : quoted_decl -> quoted_program -> quoted_program
@@ -386,15 +387,16 @@ struct
     Term.mkApp (tProj, [| kn; t |])
 
   let mkMutualInductive kn p ls =
-    let result = to_coq_list (prod tident tinductive_body)
-         (List.map (fun (a,b) ->
-                                let b = mk_ctor_list b in
-	                        pair tident tinductive_body a b) (List.rev ls)) in
+    let result = to_coq_list (prod (prod tident tTerm) tinductive_body)
+         (List.map (fun (a,b,c) ->
+                                let c = mk_ctor_list c in
+	                        pair (prod tident tTerm) tinductive_body (pair tident tTerm a b) c)
+                   (List.rev ls)) in
     Term.mkApp (pType, [| kn; p; result |])
 
     
-  let mkConstant kn c =
-    Term.mkApp (pConstr, [| kn; c |])
+  let mkConstant kn ty c =
+    Term.mkApp (pConstr, [| kn; ty; c |])
 
   let mkAxiom kn t =
     Term.mkApp (pAxiom, [| kn; t |])
@@ -539,6 +541,8 @@ struct
 	      Declarations.(Array.to_list oib.mind_user_lc)
 	      Declarations.(Array.to_list oib.mind_consnrealargs)
 	  in
+          let indty = Inductive.type_of_inductive (snd env) ((mib,oib),inst) in
+          let indty, acc = quote_term acc env indty in
 	  let (reified_ctors,acc) =
 	    List.fold_left (fun (ls,acc) (nm,ty,ar) ->
 	      debug (fun () -> Pp.(str "XXXX" ++ spc () ++
@@ -548,7 +552,7 @@ struct
 	      ((Q.quote_ident nm, ty, Q.quote_int ar) :: ls, acc))
 	      ([],acc) named_ctors
 	  in
-	  Declarations.((Q.quote_ident oib.mind_typename, (List.rev reified_ctors)) :: ls, acc))
+	  Declarations.((Q.quote_ident oib.mind_typename, indty, (List.rev reified_ctors)) :: ls, acc))
 	  ([],acc) Declarations.((Array.to_list mib.mind_packets))
       in
       let params = Q.quote_int mib.Declarations.mind_nparams in
@@ -588,37 +592,38 @@ struct
 	if Names.KNset.mem kn !visited_terms then ()
 	else
 	  begin
+            let open Declarations in
 	    visited_terms := Names.KNset.add kn !visited_terms ;
             let c = Names.Constant.make kn kn in
 	    let cd = Environ.lookup_constant c env in
-	    let do_body body =
+	    let do_body ty body =
 	      let (result,acc) =
 		try quote_term acc (Global.env ()) body
                 with e ->
                   Feedback.msg_debug (str"Exception raised while checking body of " ++ Names.pr_kn kn);
                   raise e
 	      in
-	      constants := Q.mkConstant (Q.quote_kn kn) result :: !constants
+	      constants := Q.mkConstant (Q.quote_kn kn) ty result :: !constants
 	    in
+            let ty, acc =
+              let ty =
+                match cd.const_type with
+	        | RegularArity ty -> ty
+	        | TemplateArity (ctx,ar) ->
+                   Termops.it_mkProd_or_LetIn (Constr.mkSort (Sorts.Type ar.template_level)) ctx
+              in
+              (try quote_term acc (Global.env ()) ty
+               with e ->
+                 Feedback.msg_debug (str"Exception raised while checking type of " ++ Names.pr_kn kn);
+                 raise e)
+            in
 	    Declarations.(
 	      match cd.const_body with
-		Undef _ ->
-		begin
-		  let (ty,acc) =
-		    match cd.const_type with
-		    | RegularArity ty ->
-                       (try quote_term acc (Global.env ()) ty
-                        with e ->
-                           Feedback.msg_debug (str"Exception raised while checking type of " ++ Names.pr_kn kn);
-                           raise e)
-		    | TemplateArity _ -> assert false
-		  in
-		  constants := Q.mkAxiom (Q.quote_kn kn) ty :: !constants
-		end
+		Undef _ -> constants := Q.mkAxiom (Q.quote_kn kn) ty :: !constants
 	      | Def cs ->
-		do_body (Mod_subst.force_constr cs)
+		 do_body ty (Mod_subst.force_constr cs)
 	      | OpaqueDef lc ->
-		do_body (Opaqueproof.force_proof (Global.opaque_tables ()) lc))
+		 do_body ty (Opaqueproof.force_proof (Global.opaque_tables ()) lc))
 	  end
     in
     let (quote_rem,quote_typ) =

--- a/src/reify.mli
+++ b/src/reify.mli
@@ -45,10 +45,10 @@ module type Quoter = sig
     
 
   val mkMutualInductive : quoted_kernel_name -> quoted_int (* params *) ->
-                          (quoted_ident * (quoted_ident * t * quoted_int) list) list ->
+                          (quoted_ident * t (* ind type *) *
+                             (quoted_ident * t (* constr type *) * quoted_int) list) list ->
                           quoted_decl
-
-  val mkConstant : quoted_kernel_name -> t -> quoted_decl
+  val mkConstant : quoted_kernel_name -> t -> t -> quoted_decl
   val mkAxiom : quoted_kernel_name -> t -> quoted_decl
 
   val mkExt : quoted_decl -> quoted_program -> quoted_program

--- a/src/reify.mli
+++ b/src/reify.mli
@@ -25,6 +25,9 @@ module type Quoter = sig
 
   val mkRel : quoted_int -> t
   val mkVar : quoted_ident -> t
+  val mkMeta : quoted_int -> t
+  val mkEvar : quoted_int -> t array -> t
+
   val mkSort : quoted_sort -> t
   val mkCast : t -> quoted_cast_kind -> t -> t
   val mkProd : quoted_name -> t -> t -> t
@@ -36,9 +39,10 @@ module type Quoter = sig
   val mkConstruct : quoted_inductive * quoted_int -> t
   val mkCase : (quoted_inductive * quoted_int) -> quoted_int list -> t -> t ->
                t list -> t
+  val mkProj : quoted_kernel_name -> t -> t
   val mkFix : (quoted_int array * quoted_int) * (quoted_name array * t array * t array) -> t
-  val mkUnknown : Constr.t -> t
-
+  val mkCoFix : quoted_int * (quoted_name array * t array * t array) -> t
+    
 
   val mkMutualInductive : quoted_kernel_name -> quoted_int (* params *) ->
                           (quoted_ident * (quoted_ident * t * quoted_int) list) list ->

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -112,11 +112,11 @@ struct
 
   let mkMutualInductive kn p r =
     (* FIXME: This is a quite dummy rearrangement *)
-    let r = List.map (fun (i,r) ->
-                (i,List.map (fun (id,t,n) -> (id,t),n) r)) r in
+    let r = List.map (fun (i,t,r) ->
+                ((i,t),List.map (fun (id,t,n) -> (id,t),n) r)) r in
     fun pr ->
     PType (kn,p,r,pr)
-  let mkConstant kn t = fun pr -> PConstr (kn,t,pr)
+  let mkConstant kn ty body = fun pr -> PConstr (kn,ty,body,pr)
   let mkAxiom kn t = fun pr -> PAxiom (kn,t,pr)
   let mkExt e p = e p
   let mkIn c = PIn c

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -64,9 +64,10 @@ struct
                   
   let mkRel n = Coq_tRel n
   let mkVar id = Coq_tVar id
+  let mkMeta n = Coq_tMeta n
+  let mkEvar n args = Coq_tEvar (n,Array.to_list args)
   let mkSort s = Coq_tSort s
   let mkCast c k t = Coq_tCast (c,k,t)
-  let mkUnknown trm = Coq_tUnknown (quote_string (Format.asprintf "%a" pp_constr trm))
 
   let mkConst c = Coq_tConst c
   let mkProd na t b = Coq_tProd (na, t, b)
@@ -75,13 +76,13 @@ struct
   let mkInd i = Coq_tInd i
   let mkConstruct (ind, i) = Coq_tConstruct (ind, i)
   let mkLetIn na b t t' = Coq_tLetIn (na,b,t,t')
+
+  let rec seq f t =
+    if f < t then
+      f :: seq (f + 1) t
+    else []
+
   let mkFix ((a,b),(ns,ts,ds)) =
-    let rec seq f t =
-      if f < t then
-	f :: seq (f + 1) t
-      else
-	[]
-    in
     let mk_fun xs i =
       { dname = Array.get ns i ;
         dtype = Array.get ts i ;
@@ -92,10 +93,22 @@ struct
     let block = List.rev defs in
     Coq_tFix (block, b)
 
+  let mkCoFix (a,(ns,ts,ds)) =
+    let mk_fun xs i =
+      { dname = Array.get ns i ;
+        dtype = Array.get ts i ;
+        dbody = Array.get ds i ;
+        rarg = Datatypes.O } :: xs
+    in
+    let defs = List.fold_left mk_fun [] (seq 0 (Array.length ns)) in
+    let block = List.rev defs in
+    Coq_tFix (block, a)
+
   let mkCase (ind, npar) nargs p c brs =
     let info = (ind, npar) in
     let branches = List.map2 (fun br nargs ->  (nargs, br)) brs nargs in
     Coq_tCase (info,p,c,branches)
+  let mkProj p c = Coq_tProj (p,c)
 
   let mkMutualInductive kn p r =
     (* FIXME: This is a quite dummy rearrangement *)

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -15,3 +15,6 @@ opaque.v
 letin.v
 case.v
 bugkncst.v
+evars.v
+proj.v
+cofix.v

--- a/test-suite/cofix.v
+++ b/test-suite/cofix.v
@@ -1,0 +1,7 @@
+Require Import Template.Template.
+Require Import Streams.
+
+CoFixpoint ones := Cons 1 ones.
+
+Quote Recursively Definition q_ones := ones.
+

--- a/test-suite/evars.v
+++ b/test-suite/evars.v
@@ -1,0 +1,13 @@
+Require Import Template.Template.
+
+Goal True.
+  evar (n : nat).
+  match goal with
+    H := ?t |- _ => quote_term t (fun x => pose (qn:=x))
+  end.
+  match goal with
+    qn := Ast.tEvar _ nil |- _ => idtac
+  end.
+  exact I.
+  Unshelve. exact 0.
+Qed.

--- a/test-suite/proj.v
+++ b/test-suite/proj.v
@@ -1,0 +1,18 @@
+Require Import Template.Template.
+
+Set Primitive Projections.
+
+Record Eq (A : Type) := { eq : A -> A -> bool }.
+
+Goal forall {A} {e : Eq A} x y, e.(eq _) x y = eq _ e x y.
+Proof.
+  intros.
+  match goal with
+   |- ?T => quote_term T (fun x => pose (qgoal:=x))
+  end.
+Show.
+  match goal with
+    H:= context [Ast.tProj "Top.proj.eq" _] |- _ => idtac
+  end.
+  reflexivity.
+Qed.

--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -26,7 +26,7 @@ Record def (term : Set) : Set := mkdef
 { dname : name (** the name (note, this may mention other definitions **)
 ; dtype : term
 ; dbody : term (** the body (a lambda term) **)
-; rarg  : nat  (** the index of the recursive argument **)
+; rarg  : nat  (** the index of the recursive argument, 0 for cofixpoints **)
 }.
 
 Definition mfixpoint (term : Set) : Set :=
@@ -34,9 +34,9 @@ Definition mfixpoint (term : Set) : Set :=
 
 Inductive term : Set :=
 | tRel       : nat -> term
-| tVar       : ident -> term (** this can go away **)
+| tVar       : ident -> term (** For free variables (e.g. in a goal) *)
 | tMeta      : nat -> term   (** NOTE: this can go away *)
-| tEvar      : nat -> term
+| tEvar      : nat -> list term -> term
 | tSort      : sort -> term
 | tCast      : term -> cast_kind -> term -> term
 | tProd      : name -> term (** the type **) -> term -> term
@@ -48,11 +48,9 @@ Inductive term : Set :=
 | tConstruct : inductive -> nat -> term
 | tCase      : (inductive * nat) (* # of parameters *) -> term (** type info **) -> term ->
                list (nat * term) -> term
+| tProj      : string -> term -> term
 | tFix       : mfixpoint term -> nat -> term
-(*
-| CoFix     of ('constr, 'types) pcofixpoint
-*)
-| tUnknown : string -> term.
+| tCoFix     : mfixpoint term -> nat -> term.
 
 Record inductive_body := mkinductive_body
 { ctors : list (ident * term * nat (* arity, w/o lets, w/o parameters *)) }.

--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -56,9 +56,9 @@ Record inductive_body := mkinductive_body
 { ctors : list (ident * term * nat (* arity, w/o lets, w/o parameters *)) }.
 
 Inductive program : Set :=
-| PConstr : string -> term -> program -> program
+| PConstr : string -> term (* type *) -> term (* body *) -> program -> program
 | PType   : ident -> nat (* # of parameters, w/o let-ins *) ->
-            list (ident * inductive_body) -> program -> program
+            list (ident * term (* type *) * inductive_body) -> program -> program
 | PAxiom  : ident -> term (* the type *) -> program -> program
 | PIn     : term -> program.
 

--- a/theories/TemplateCoqCompiler.v
+++ b/theories/TemplateCoqCompiler.v
@@ -1,3 +1,3 @@
-Require Import String Template.Ast BinNat.
+Require Import String Template.Ast.
 
 Declare ML Module "template_coq_plugin".


### PR DESCRIPTION
- Now PType carries the (checked) type of constants as well as their bodies
- CoFixpoints, Projections, Metas and Evars are quoted as well, evars taking their substitution as argument (denotation is missing though)
- denotation of constants and sorts works by generating fresh universes if necessary.